### PR TITLE
updated logic for showing "goal begins"

### DIFF
--- a/app/controllers/goals_controller.rb
+++ b/app/controllers/goals_controller.rb
@@ -17,8 +17,6 @@ class GoalsController < ApplicationController
     @started = @goal.insights.where(status: "Getting started on goal")
     @progress = @goal.insights.where(status: "Making progress on goal")
     @closer = @goal.insights.where(status: "Getting closer to goal")
-    @check_if_goal_accomplished = goal_accomplished?
-    @no_insight = got_insights?
   end
 
   def new
@@ -60,21 +58,5 @@ class GoalsController < ApplicationController
 
   def goal_params
     params.require(:goal).permit(:goal_type, :name, :description, :status, :photo)
-  end
-
-  def goal_accomplished?
-    if @goal.status == "Goal accomplished"
-      return true
-    else
-      return false
-    end
-  end
-
-  def got_insights?
-    if @insight.nil?
-      return true
-    else
-      return false
-    end
   end
 end

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -6,6 +6,9 @@ class Goal < ApplicationRecord
   has_one_attached :photo
 
   validates :goal_type, :name, :description, :status, presence: true
+  def accomplished?
+    status == "Goal accomplished"
+  end
 
   def goal_icon
     case goal_type

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -71,7 +71,7 @@
       <!--Closer-->
       <div class="one-bookcase-section">
         <div class="status-cover-container">
-          <% if @check_if_goal_accomplished %>
+          <% if @goal.accomplished? %>
             <div id="goal-accomplished">Goal <br>accomplished
             </div>
             <% else %>
@@ -114,12 +114,10 @@
       <!--Thinking-->
       <div class="one-bookcase-section">
         <div class="status-cover-container">
-          <% if @no_insight %>
-            <div id="got-no-insight">Goal begins
-            </div>
+          <% if @insights.empty? %>
+            <div id="got-no-insight">Goal begins</div>
             <% else %>
-            <div id="got-insight">
-            </div>
+            <div id="got-insight"></div>
           <% end %>
           <div class="status-cover-plank">
           </div>


### PR DESCRIPTION
# Description

Summary of the changes:

- @goal.insights is an array -> used @goal.insights.empty instead of @goal.insights.nil

Link to the ticket:
​

# How Has This Been Tested?

- [x] Screenshot A
<img width="446" alt="image" src="https://user-images.githubusercontent.com/121034558/229020632-5b8e4b75-916e-4484-92b6-f19e0ce38ca7.png">

- [x] Screenshot B
<img width="1291" alt="image" src="https://user-images.githubusercontent.com/121034558/229020777-90cdafa4-288a-4264-a60e-71733f796e68.png">


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
