### PR TITLE
closed off div

### DIFF
--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -91,7 +91,7 @@
               </div>
               <div class="book-container">
                 <div class="book-cover" id="closer-colour">
-                /div>
+                </div>
                 <div class="book-strip-one">-----
                 </div>
                 <div class="book-strip-two">-----


### PR DESCRIPTION
# Description

Summary of the changes:
Closed off a div 

Issue (has been solved): 
<img width="1287" alt="image" src="https://user-images.githubusercontent.com/121034558/229055169-a6b0a5f6-a30c-461b-b540-afa4e187276a.png">

Link to the ticket:
​

# How Has This Been Tested?

- [ ] Screenshot A
- [ ] Screenshot B

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
